### PR TITLE
Correctness fixes across templates and image pipeline

### DIFF
--- a/build/image-process.js
+++ b/build/image-process.js
@@ -79,7 +79,11 @@ module.exports = ({ input, width, alt, lazy, className = 'shadow-black-transpare
             createWebp(paths.webpPath2x, retinaWidth)
         ] : []))
             .then((info) => {
-                const baseImage = info[0];
+                const baseImage = info && info[0];
+                if (!baseImage) {
+                    console.warn('Skipping lazy image render; sharp produced no base output for', input);
+                    return '';
+                }
                 return lazyImage({ width: baseImage.width, height: baseImage.height });
             })
             .catch((error) => console.error('Error in lazy image: ', error));
@@ -93,7 +97,11 @@ module.exports = ({ input, width, alt, lazy, className = 'shadow-black-transpare
         createWebp(paths.webpPath2x, retinaWidth)
     ] : []))
         .then((info) => {
-            const baseImage = info[0];
+            const baseImage = info && info[0];
+            if (!baseImage) {
+                console.warn('Skipping eager image render; sharp produced no base output for', input);
+                return '';
+            }
             return eagerImage({ width: baseImage.width, height: baseImage.height });
         })
         .catch((error) => console.error('Error in eager image: ', error));

--- a/src/_includes/layouts/readme-en.njk
+++ b/src/_includes/layouts/readme-en.njk
@@ -17,7 +17,7 @@ layout: layouts/base-header-profile.njk
                         {%- include "md/en/readme-intro.md" -%}
                         {% endmarkdown %}
                         
-                        <h3 class="">Table of Content</h3>
+                        <h3 class="">{{ collections.t[locale].toc }}</h3>
                         {{ content | toc | safe }}  
                         
                         {{ content | safe }}

--- a/src/_includes/layouts/readme-es.njk
+++ b/src/_includes/layouts/readme-es.njk
@@ -17,7 +17,7 @@ layout: layouts/base-header-profile.njk
                             ¡Hola! My name is Edwin Torres or Edwin Torres Hernández or Edwin Torres-Hernandez or just Edwin. I'm a father of two, a boricua (Puerto Rican), and the husband of a minister of Presbyterian Church (U.S.A.). My mother tongue is Spanish, but I learned English during my twenties. My pronouns are he/él.
                         </p>
 
-                        <h3 class="">Table of Content</h3>
+                        <h3 class="">{{ collections.t[locale].toc }}</h3>
                         {{ content | toc | safe }}  
                         
                         {{ content | safe }}

--- a/src/_includes/shared/footer.njk
+++ b/src/_includes/shared/footer.njk
@@ -4,7 +4,7 @@
             <div class="row">
                 <div class="col-lg-4 col-12 mb-0 mb-md-4 pb-0 pb-md-2">
                     <a href="#" class="logo-footer">
-                        <img src="{{ '/assets/images/logo-light.png' | hash }}" height="24" alt="">
+                        <img src="{{ '/assets/images/logo-light.png' | hash }}" height="24" alt="Edwin Torres">
                     </a>
                     <p class="mt-4 text-foot">{{ collections.t[locale].heroCallout }} {{ collections.t[locale].typedMessage5 }}</p>
 

--- a/src/_includes/shared/navbar-header-overlay.njk
+++ b/src/_includes/shared/navbar-header-overlay.njk
@@ -4,8 +4,8 @@
             <!-- Logo container-->
             <div>
                     <a class="logo" href="/">
-                        <img src="{{ '/assets/images/edtorr.png' | hash }}" class="l-dark" height="24" alt="">
-                        <img src="{{ '/assets/images/logo-light.png' | hash }}" class="l-light" height="24" alt="">
+                        <img src="{{ '/assets/images/edtorr.png' | hash }}" class="l-dark" height="24" alt="Edwin Torres">
+                        <img src="{{ '/assets/images/logo-light.png' | hash }}" class="l-light" height="24" alt="Edwin Torres">
                     </a>
             </div>         
             <!--end login button-->

--- a/src/_includes/shared/navbar.njk
+++ b/src/_includes/shared/navbar.njk
@@ -4,7 +4,7 @@
             <!-- Logo container-->
             <div>
                 <a class="logo" href="/">
-                    <img src="{{ '/assets/images/edtorr.png' | hash }}" height="24" alt="">
+                    <img src="{{ '/assets/images/edtorr.png' | hash }}" height="24" alt="Edwin Torres">
                 </a>
             </div>             
             <!--end login button-->

--- a/src/_includes/shared/pagination-post.njk
+++ b/src/_includes/shared/pagination-post.njk
@@ -5,7 +5,7 @@
       {%- set previousPost = collections.posts | getPreviousCollectionItem(page) %}
       <li class="page-item"> {%- if previousPost %}<a class="page-link" href="{{ previousPost.url | url }}" aria-label="Previous">{{ previousPost.data.title }}</a></li>{% endif %}
       {%- set nextPost = collections.posts | getNextCollectionItem(page) %} 
-      <li class="page-item"> {%- if nextPost %}<a class="page-link" href="{{ nextPost.url | url }}" aria-label="Mext">{{ nextPost.data.title }}</a></li>{% endif %}
+      <li class="page-item"> {%- if nextPost %}<a class="page-link" href="{{ nextPost.url | url }}" aria-label="Next">{{ nextPost.data.title }}</a></li>{% endif %}
     </ul>
 </div>
 <!-- Pagination End -->

--- a/src/en/posts/a-day-in-the-life-of-an-18f-engineer.md
+++ b/src/en/posts/a-day-in-the-life-of-an-18f-engineer.md
@@ -1,6 +1,6 @@
 ---
 title: A day in the life of an 18F Engineer
-description: 
+description: A day in the life of a bilingual engineer at 18F, building accessible government services for the millions of Spanish-speakers in the United States.
 date: 2021-09-30
 author: Edwin Torres
 headerImage: /assets/images/blog/18F/2022.jpg

--- a/src/es/posts/un-dia-en-la-vida-de-un-ingeniero-de-18f.md
+++ b/src/es/posts/un-dia-en-la-vida-de-un-ingeniero-de-18f.md
@@ -1,6 +1,6 @@
 ---
 title: Un dia en la vida de un ingeniero de 18F
-description: 
+description: Un día en la vida de un ingeniero bilingüe en 18F, construyendo servicios de gobierno accesibles para los millones de hispanohablantes en Estados Unidos.
 date: 2021-09-30
 author: Edwin Torres
 headerImage: /assets/images/blog/18F/2021.jpg


### PR DESCRIPTION
## Summary
- Fixes a typo (Mext to Next) in pagination ARIA label
- Guards against sharp returning no base output in the image pipeline so a single image failure stops one render instead of crashing the build
- Adds descriptive alt text to logo images that previously had empty alt
- Localizes the Table of Content header in readme-en.njk and readme-es.njk to match the pattern already used in readme.njk
- Adds missing description frontmatter to both 18F engineer posts so meta description and Open Graph tags are populated

## Test plan
- [ ] Confirm the dev server build log no longer shows the "Cannot read properties of undefined (reading 'width')" errors
- [ ] View source on a blog post and confirm the next-link aria-label reads "Next"
- [ ] Inspect a page header or footer and confirm the logo img tag has alt="Edwin Torres"
- [ ] Visit /en/pages/work-timeline/ and confirm the TOC heading renders correctly
- [ ] Share /en/blog/a-day-in-the-life-of-an-18f-engineer/ on LinkedIn and confirm the preview description is populated