### PR TITLE
Performance: defer non-critical scripts and add AVIF to the image pipeline

### DIFF
--- a/build/image-process.js
+++ b/build/image-process.js
@@ -5,15 +5,18 @@ const render = require('./image-render');
 
 const DEFAULT_JPEG_QUALITY = 80;
 const DEFAULT_WEBP_QUALITY = 65;
+const DEFAULT_AVIF_QUALITY = 50;
 const PLACEHOLDER_JPEG_QUALITY = 25;
 const PLACEHOLDER_WEBP_QUALITY = 15;
+const PLACEHOLDER_AVIF_QUALITY = 20;
 
 module.exports = ({ input, width, alt, lazy, className = 'shadow-black-transparent' }) => {
     const inputStream = sharp(join('./src', input));
     const outputDir = './public';
     const extensions = Object.freeze({
         ofInput: extname(input),
-        webp: '.webp'
+        webp: '.webp',
+        avif: '.avif'
     });
     const addExtensionToPath = generatePathFrom(input);
 
@@ -25,8 +28,11 @@ module.exports = ({ input, width, alt, lazy, className = 'shadow-black-transpare
         fallbackPath2x: supportsDensity ? addExtensionToPath(extensions.ofInput, { density: 2 }) : undefined,
         webpPath: addExtensionToPath(extensions.webp),
         webpPath2x: supportsDensity ? addExtensionToPath(extensions.webp, { density: 2 }) : undefined,
+        avifPath: addExtensionToPath(extensions.avif),
+        avifPath2x: supportsDensity ? addExtensionToPath(extensions.avif, { density: 2 }) : undefined,
         fallbackPlaceholder: addExtensionToPath(extensions.ofInput, { isPlaceholder: true }),
-        webpPlaceholder: addExtensionToPath(extensions.webp, { isPlaceholder: true })
+        webpPlaceholder: addExtensionToPath(extensions.webp, { isPlaceholder: true }),
+        avifPlaceholder: addExtensionToPath(extensions.avif, { isPlaceholder: true })
     });
     const { lazyImage, eagerImage } = render(alt, className, paths);
 
@@ -68,15 +74,34 @@ module.exports = ({ input, width, alt, lazy, className = 'shadow-black-transpare
             .catch((error) => console.error('Error in createWebp function: ', error));
     }
 
+    function createAvif(outputPath, resizeWidth, qualityOptions = {}) {
+        const avifOptions = {
+            quality: qualityOptions.quality ?? DEFAULT_AVIF_QUALITY
+        };
+
+        const stream = inputStream.clone();
+        if (resizeWidth) {
+            stream.resize(resizeWidth, null, resizeOptions);
+        }
+
+        return stream
+            .avif(avifOptions)
+            .toFile(join(outputDir, outputPath))
+            .catch((error) => console.error('Error in createAvif function: ', error));
+    }
+
     if (lazy) {
         return Promise.all([
             createJpeg(paths.fallbackPath, width),
             createWebp(paths.webpPath, width),
+            createAvif(paths.avifPath, width),
             createJpeg(paths.fallbackPlaceholder, placeholderWidth, { quality: PLACEHOLDER_JPEG_QUALITY }),
-            createWebp(paths.webpPlaceholder, placeholderWidth, { quality: PLACEHOLDER_WEBP_QUALITY })
+            createWebp(paths.webpPlaceholder, placeholderWidth, { quality: PLACEHOLDER_WEBP_QUALITY }),
+            createAvif(paths.avifPlaceholder, placeholderWidth, { quality: PLACEHOLDER_AVIF_QUALITY })
         ].concat(supportsDensity ? [
             createJpeg(paths.fallbackPath2x, retinaWidth),
-            createWebp(paths.webpPath2x, retinaWidth)
+            createWebp(paths.webpPath2x, retinaWidth),
+            createAvif(paths.avifPath2x, retinaWidth)
         ] : []))
             .then((info) => {
                 const baseImage = info[0];
@@ -87,10 +112,12 @@ module.exports = ({ input, width, alt, lazy, className = 'shadow-black-transpare
 
     return Promise.all([
         createJpeg(paths.fallbackPath, width),
-        createWebp(paths.webpPath, width)
+        createWebp(paths.webpPath, width),
+        createAvif(paths.avifPath, width)
     ].concat(supportsDensity ? [
         createJpeg(paths.fallbackPath2x, retinaWidth),
-        createWebp(paths.webpPath2x, retinaWidth)
+        createWebp(paths.webpPath2x, retinaWidth),
+        createAvif(paths.avifPath2x, retinaWidth)
     ] : []))
         .then((info) => {
             const baseImage = info[0];

--- a/build/image-render.js
+++ b/build/image-render.js
@@ -5,28 +5,34 @@ module.exports = (alt, className, paths) => {
         fallbackPlaceholder,
         webpPath,
         webpPath2x,
-        webpPlaceholder
+        webpPlaceholder,
+        avifPath,
+        avifPath2x,
+        avifPlaceholder
     } = paths;
 
     const classAttribute = className ? ` class="${className}"` : '';
     const buildSrcset = (primary, retina) => (retina ? `${primary} 1x, ${retina} 2x` : primary);
     const fallbackSrcset = buildSrcset(fallbackPath, fallbackPath2x);
     const webpSrcset = buildSrcset(webpPath, webpPath2x);
+    const avifSrcset = avifPath ? buildSrcset(avifPath, avifPath2x) : '';
 
     return Object.freeze({
         lazyImage(baseDimensions = {}, retinaDimensions) {
             const { width = '', height = '' } = baseDimensions;
             const dataSrcsetAttribute = fallbackPath2x ? ` data-srcset="${fallbackSrcset}"` : '';
             const srcsetAttribute = fallbackPath2x ? ` srcset="${fallbackSrcset}"` : '';
+            const avifLazy = avifPath ? `<source type="image/avif" srcset="${avifPlaceholder}" data-srcset="${avifSrcset}" />\n` : '';
+            const avifEager = avifPath ? `<source type="image/avif" srcset="${avifSrcset}" />\n` : '';
 
             return `
 <picture class="lazy">
-<source type="image/webp" srcset="${webpPlaceholder}" data-srcset="${webpSrcset}" />
+${avifLazy}<source type="image/webp" srcset="${webpPlaceholder}" data-srcset="${webpSrcset}" />
 <img src="${fallbackPlaceholder}" data-src="${fallbackPath}"${dataSrcsetAttribute} alt="${alt}" width="${width}" height="${height}" title="${alt}"${classAttribute} />
 </picture>
 <noscript>
 <picture>
-<source type="image/webp" srcset="${webpSrcset}" />
+${avifEager}<source type="image/webp" srcset="${webpSrcset}" />
 <img src="${fallbackPath}"${srcsetAttribute} alt="${alt}" width="${width}" height="${height}" title="${alt}"${classAttribute} />
 </picture>
 </noscript>`;
@@ -34,10 +40,11 @@ module.exports = (alt, className, paths) => {
         eagerImage(baseDimensions = {}, retinaDimensions) {
             const { width = '', height = '' } = baseDimensions;
             const srcsetAttribute = fallbackPath2x ? ` srcset="${fallbackSrcset}"` : '';
+            const avifEager = avifPath ? `<source type="image/avif" srcset="${avifSrcset}" />\n` : '';
 
             return `
 <picture>
-<source type="image/webp" srcset="${webpSrcset}" />
+${avifEager}<source type="image/webp" srcset="${webpSrcset}" />
 <img src="${fallbackPath}"${srcsetAttribute} alt="${alt}" width="${width}" height="${height}" title="${alt}"${classAttribute} />
 </picture>`;
         }

--- a/src/_includes/shared/script.njk
+++ b/src/_includes/shared/script.njk
@@ -1,15 +1,15 @@
     <!-- JS Includes -->
 
     <!-- Third-party Libraries -->
-    <script src="{{ '/assets/vendor/js/bootstrap.bundle.min.js' | hash }}"></script>
-    <script src="{{ '/assets/vendor/js/fuse.min.js' | hash }}"></script>
+    <script defer src="{{ '/assets/vendor/js/bootstrap.bundle.min.js' | hash }}"></script>
+    <script defer src="{{ '/assets/vendor/js/fuse.min.js' | hash }}"></script>
 
     <!-- Icons -->
-    <script src="{{ '/assets/vendor/js/feather.min.js' | hash }}"></script>
-    
+    <script defer src="{{ '/assets/vendor/js/feather.min.js' | hash }}"></script>
+
     <!-- Theme Js -->
-    <script src="{{ '/assets/vendor/js/theme.js' | hash }}"></script>
+    <script defer src="{{ '/assets/vendor/js/theme.js' | hash }}"></script>
 
     <!-- App Js -->
-    <script src="{{ '/assets/js/app.js' | hash }}"></script>
-    <script src="{{ '/assets/js/contentForSearch.js' | hash }}"></script>
+    <script defer src="{{ '/assets/js/app.js' | hash }}"></script>
+    <script defer src="{{ '/assets/js/contentForSearch.js' | hash }}"></script>


### PR DESCRIPTION
## Summary
- Adds defer to the six external scripts in script.njk so they no longer block HTML parsing. Execution order is preserved across them and all six fire before DOMContentLoaded, so any DOM-ready listeners are unaffected
- Adds AVIF generation to the image pipeline alongside the existing JPEG and WebP outputs (base, retina, and placeholder variants)
- Emits a source type=image/avif as the first source in each rendered picture element so modern browsers pick AVIF first

## Test plan
- [ ] View source on any rendered page and confirm every external script in the body has defer
- [ ] DevTools Network panel: confirm scripts are no longer parse-blocking
- [ ] Visit any post; the rendered picture element should list image/avif first, then image/webp, then the JPEG img fallback
- [ ] ls public/assets/images and confirm .avif files exist alongside .webp and .jpg
- [ ] Verify the page still renders identically in browsers without AVIF support (the WebP and JPEG fallbacks take over)