### PR TITLE
Filter prev/next pagination by locale and add it to all post layouts

### DIFF
--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -27,7 +27,7 @@ layout: layouts/base-header.njk
                 </div>
                 <!-- Content-Post End -->
 
-                
+                {% include "shared/pagination-post.njk" %}
 
             </div><!--end col-->
 

--- a/src/_includes/shared/pagination-post.njk
+++ b/src/_includes/shared/pagination-post.njk
@@ -2,9 +2,10 @@
 <!-- Pagination Start -->
 <div class="col-12">
     <ul class="pagination justify-content-center mb-0">
-      {%- set previousPost = collections.posts | getPreviousCollectionItem(page) %}
+      {%- set localizedPosts = collections.posts | byLocale(locale) %}
+      {%- set previousPost = localizedPosts | getPreviousCollectionItem(page) %}
       <li class="page-item"> {%- if previousPost %}<a class="page-link" href="{{ previousPost.url | url }}" aria-label="Previous">{{ previousPost.data.title }}</a></li>{% endif %}
-      {%- set nextPost = collections.posts | getNextCollectionItem(page) %} 
+      {%- set nextPost = localizedPosts | getNextCollectionItem(page) %}
       <li class="page-item"> {%- if nextPost %}<a class="page-link" href="{{ nextPost.url | url }}" aria-label="Next">{{ nextPost.data.title }}</a></li>{% endif %}
     </ul>
 </div>


### PR DESCRIPTION
## Summary
- pagination-post.njk now filters via collections.posts | byLocale(locale), matching the pattern recent-posts.njk already uses. Previously it used the unfiltered collections.posts, so English posts linked to Spanish counterparts and vice versa
- Adds the pagination partial to layouts/post.njk so all blog posts (not just the ones using post-header-overlay) get prev/next links

## Production bug being fixed
The Implementation Plan post on production currently shows:
- Previous: "Sirviendo al Pueblo, en lo Público y lo Privado" (Spanish)
- Next: "El plan de implementación..." (Spanish version of itself)

After this merges, the EN chain stays EN: a-day-in-the-life → serving-the-people → implementation-plans, and the ES chain stays ES.

## Test plan
- [ ] Visit /en/blog/serving-the-people-in-public-and-private/ — prev/next should point to /en/ posts only
- [ ] Visit /es/blog/sirviendo-al-pueblo-en-lo-publico-y-lo-privado/ — prev/next should point to /es/ posts only
- [ ] Confirm the Implementation Plan post (uses post-header-overlay) still shows prev/next, now correctly filtered