### PR TITLE
Gate GA to production builds and redirect four more stale draft URLs

### DIFF
--- a/src/.htaccess
+++ b/src/.htaccess
@@ -4,6 +4,10 @@ AddType application/json .json
 # 301 redirects for stale draft URLs of the Implementation Plan post
 Redirect 301 /en/blog/implementation-plans-specs-that-stay-alive/ /en/blog/implementation-plans-how-to-keep-context/
 Redirect 301 /en/blog/the-implementation-plan:-how-to-keep-context-when-ai-codes-faster-than-you-can-think/ /en/blog/implementation-plans-how-to-keep-context/
+Redirect 301 /en/blog/no-gaps-ever-the-ip-system-behind-a-solo-founder-monorepo/ /en/blog/implementation-plans-how-to-keep-context/
+Redirect 301 /en/blog/no-gaps-ever-an-introduction-to-the-implementation-plan-system/ /en/blog/implementation-plans-how-to-keep-context/
+Redirect 301 /en/blog/the-implementation-plan-system-as-memory/ /en/blog/implementation-plans-how-to-keep-context/
+Redirect 301 /en/blog/when-documentation-stopped-fighting-me/ /en/blog/implementation-plans-how-to-keep-context/
 Redirect 301 /es/blog/planes-de-implementacion-especificaciones-que-permanecen-vivas/ /es/blog/planes-de-implementacion-como-mantener-el-contexto/
 
 # 301 redirects for tag pages that only existed for the renamed draft

--- a/src/_data/env.js
+++ b/src/_data/env.js
@@ -1,0 +1,3 @@
+module.exports = {
+    isProduction: process.env.NODE_ENV === 'production'
+};

--- a/src/_includes/shared/head.njk
+++ b/src/_includes/shared/head.njk
@@ -111,6 +111,7 @@
   <!-- Web App Manifest (For PWA and Android) -->
   <link rel="manifest" href="{{ '/assets/images/favicon/manifest.json' | hash }}">
 
+  {% if env.isProduction %}
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-T5HZMBG9DM"></script>
   <script>
@@ -120,5 +121,6 @@
 
     gtag('config', 'G-T5HZMBG9DM');
   </script>
+  {% endif %}
 
 </head>


### PR DESCRIPTION
## Summary
- Adds src/_data/env.js exposing env.isProduction based on process.env.NODE_ENV
- Wraps the gtag script block in head.njk in {% if env.isProduction %} so it only emits when building with NODE_ENV=production (the npm run build script already sets this; npm start does not)
- Verified with two one-shot eleventy builds: dev build → 0 hits on googletagmanager in rendered HTML, prod build → 1 hit
- Adds 301 redirects for four more stale draft URLs discovered in the GA URL-based report

## Why
The GA URL report showed 56+ pageviews for /en/blog/no-gaps-ever-the-ip-system-behind-a-solo-founder-monorepo/ and three other slugs that never existed in git history. All from 1 active user. The traffic came from dev-server previews during drafting, not real visitors. This change stops dev pageviews from polluting GA going forward.

## Test plan
- [ ] Run npm start and view source on any page — no googletagmanager script
- [ ] Run NODE_ENV=production npm run build and view a generated file in public/ — googletagmanager script present
- [ ] After deploy, curl -I https://edtorr.com/en/blog/no-gaps-ever-the-ip-system-behind-a-solo-founder-monorepo/ — confirm 301 to canonical post