### PR TITLE
[codex] publish AI planning post

### DIFF
--- a/src/en/posts/when-ai-moves-non-determinism-inside-the-workflow.md
+++ b/src/en/posts/when-ai-moves-non-determinism-inside-the-workflow.md
@@ -7,8 +7,6 @@ author: Edwin Torres
 headerImage: /assets/images/blog/when-ai-moves-non-determinism-inside-the-workflow-hero.jpg
 headerImageAlt: Warm orange arches inside an auditorium, viewed from the seating area toward the stage.
 locale: en
-draft: true
-eleventyExcludeFromCollections: true
 translation: /es/blog/los-agentes-de-ia-cambian-donde-ocurre-la-planificacion/
 tags:
   - engineering

--- a/src/es/posts/los-flujos-agenticos-cambian-donde-ocurre-la-planificacion.md
+++ b/src/es/posts/los-flujos-agenticos-cambian-donde-ocurre-la-planificacion.md
@@ -8,8 +8,6 @@ author: Edwin Torres
 headerImage: /assets/images/blog/when-ai-moves-non-determinism-inside-the-workflow-hero.jpg
 headerImageAlt: Arcos anaranjados y cálidos dentro de un auditorio, vistos desde el área de asientos hacia el escenario.
 locale: es
-draft: true
-eleventyExcludeFromCollections: true
 tags:
   - ingeniería
   - ingeniería-de-datos


### PR DESCRIPTION
## What changed

- Removed draft and collection-exclusion flags from the English and Spanish AI planning posts.
- This makes the posts appear in homepage recent posts, blog indexes, tag pages, feeds, and other collection-driven surfaces.

## Why

The earlier PR shipped the posts as direct draft URLs. This follow-up publishes them now that the release path is approved.

## Validation

- Ran npm run build successfully.
- Verified the new English and Spanish posts appear in generated homepage/blog output.